### PR TITLE
Correct way to specify pod Swift version

### DIFF
--- a/LiveChat.podspec
+++ b/LiveChat.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Sources/*.{swift}'
   s.resources = 'Sources/*.{js}'
   s.frameworks = 'UIKit', 'WebKit'
-  s.xcconfig = { 'SWIFT_VERSION' => '4.0' }
+  s.swift_version = '4.0'  
 end


### PR DESCRIPTION
Using `s.xcconfig = { 'SWIFT_VERSION' => '4.0' }` with projects that use Swift 4.2 results in Cocoapods warnings upon pod install

_The Trader [Debug] target overrides the SWIFT_VERSION build setting defined in Pods/Target Support Files/Pods-Trader/Pods-Trader.debug.xcconfig. This can lead to problems with the CocoaPods installation_

The correct way to define the Pod Swift version is s.swift_version = '4.0'
https://blog.cocoapods.org/CocoaPods-1.4.0/#swift-version-dsl