### PR TITLE
fixed email parsing

### DIFF
--- a/Sources/URLBuilder.swift
+++ b/Sources/URLBuilder.swift
@@ -22,7 +22,7 @@ func buildUrl(templateURL: String, configuration: LiveChatConfiguration, customV
     }
     
     if configuration.email != "" {
-        let escapedEmail = configuration.email.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)
+        let escapedEmail = configuration.email.addingPercentEncoding(withAllowedCharacters: .alphanumerics)
         if let escapedEmail = escapedEmail {
             chatURL = chatURL.appending("&email=" + escapedEmail)
         }


### PR DESCRIPTION
Hello! there is a problem located in URLBuilder.swift.  function configuration.email.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) does not encode + sign 
so email test+3@test.com will transform to test3+%40test.com and after that, this url is passed to webview so the result in support form I'm getting empty space instead of +

so plz switch from .urlHostAllowed -> .alphanumerics and this case will work